### PR TITLE
Fix keyframe percent and bezier caching

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -160,6 +160,23 @@ function App() {
 			engine.run();
 		});
 
+		// percent 100
+		engine.resourceManager.load<Entity>({
+			urls: [
+				"https://gw.alipayobjects.com/os/OasisHub/cb3c7c17-d0c0-4ba3-bbb6-bb009ccd6f96/lottie.json",
+				"https://gw.alipayobjects.com/os/OasisHub/62c1e950-49c7-4428-a47d-d628696330ea/lottie.atlas"
+			],
+			type: 'lottie'
+		}).then(async (lottieEntity) => {
+			root.addChild(lottieEntity);
+			const lottie:LottieAnimation = lottieEntity.getComponent(LottieAnimation);
+			lottie.isLooping = true;
+			lottieEntity.transform.setPosition(5.5, 2, 0);
+			lottieEntity.transform.setScale(0.5, 0.5, 0.5);
+			lottie.play();
+			engine.run();
+		});
+
 
 		engine.run();
 	}, []);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vite": "1.0.0-rc.5",
     "vite-plugin-react": "^3.0.0"
   },
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Lotte runtime of oasis engine",
   "name": "@oasis-engine/lottie",
   "ci": {

--- a/src/core/property/BaseProperty.ts
+++ b/src/core/property/BaseProperty.ts
@@ -23,6 +23,7 @@ export type TypeKeyframe = {
   ti?: number[];
   to?: number[];
   beziers?: BezierEasing.EasingFunction[];
+  timeBezier?: BezierEasing.EasingFunction;
   bezierData?: { segmentLength: number, points: TypePoint[] },
   n?: string,
 }

--- a/src/core/property/KeyframedMultidimensionalProperty.ts
+++ b/src/core/property/KeyframedMultidimensionalProperty.ts
@@ -79,8 +79,13 @@ export default class KeyframedMultidimensionalProperty extends BaseProperty {
 
       // Time bezier easing
       const bezier = bez.getBezierEasing(keyData.o.x, keyData.o.y, keyData.i.x, keyData.i.y, keyData.n);
-      let t = (frameNum - keyTime) / (nextKeyTime - keyTime);
-      t = Math.min(Math.max(0, t), 1) % 1;
+
+      let t = 0;
+
+      if (keyTime >= 0) {
+        t = (frameNum - keyTime) / (nextKeyTime - keyTime);
+        t = Math.min(Math.max(0, t), 1);
+      }
 
       const percent: number = bezier(t);
 

--- a/src/core/property/KeyframedMultidimensionalProperty.ts
+++ b/src/core/property/KeyframedMultidimensionalProperty.ts
@@ -80,7 +80,7 @@ export default class KeyframedMultidimensionalProperty extends BaseProperty {
       // Time bezier easing
       const bezier = bez.getBezierEasing(keyData.o.x, keyData.o.y, keyData.i.x, keyData.i.y, keyData.n);
       let t = (frameNum - keyTime) / (nextKeyTime - keyTime);
-      t = Math.min(Math.max(0, t), 1);
+      t = Math.min(Math.max(0, t), 1) % 1;
 
       const percent: number = bezier(t);
 

--- a/src/core/property/KeyframedMultidimensionalProperty.ts
+++ b/src/core/property/KeyframedMultidimensionalProperty.ts
@@ -77,8 +77,13 @@ export default class KeyframedMultidimensionalProperty extends BaseProperty {
 
       const { points, segmentLength } = keyData.bezierData;
 
-      // Time bezier easing
-      const bezier = bez.getBezierEasing(keyData.o.x, keyData.o.y, keyData.i.x, keyData.i.y, keyData.n);
+      let bezier = keyData.timeBezier;
+
+      // Cache time bezier easing
+      if (!bezier) {
+        bezier = bez.getBezierEasing(keyData.o.x, keyData.o.y, keyData.i.x, keyData.i.y, keyData.n);
+        keyData.timeBezier = bezier;
+      }
 
       let t = 0;
 
@@ -124,9 +129,11 @@ export default class KeyframedMultidimensionalProperty extends BaseProperty {
       caching.lastPoint = lastPoint;
       caching.addedLength = addedLength;
     } else {
-      keyData.beziers = [];
+      if (!keyData.beziers) {
+        keyData.beziers = [];
+      }
 
-      for (let i = 0, len = keyData.s.length; i < len; i += 1) {
+      for (let i = 0, len = keyData.s.length; i < len; i++) {
         newValue[i] = this.getValue(frameNum, i, keyData, nextKeyData);
       }
     }

--- a/src/core/property/KeyframedValueProperty.ts
+++ b/src/core/property/KeyframedValueProperty.ts
@@ -59,7 +59,10 @@ export default class KeyframedValueProperty extends BaseProperty {
     }
 
     caching.lastIndex = lastIndex;
-    keyData.beziers = [];
+
+    if (!keyData.beziers) {
+      keyData.beziers = [];
+    }
 
     this.v = this.getValue(frameNum, 0, keyData, nextKeyData) * this.mult;
   }


### PR DESCRIPTION
Fix:
- Keyframe percent: keep the keyframe percent to `0` if the `keyTime` is less than `0`
- Bezier caching: cache the bezier easing functions.